### PR TITLE
add getattr ot parameters

### DIFF
--- a/csql/models/query.py
+++ b/csql/models/query.py
@@ -74,3 +74,7 @@ class Parameters:
 	def __getitem__(self, key: str) -> ParameterPlaceholder:
 		paramVal = self.params[key] # check existence
 		return ParameterPlaceholder(key=key)
+	
+	def __getattr__(self, key: str) -> ParameterPlaceholder:
+		paramVal = self.params[key] # check existence
+		return ParameterPlaceholder(key=key)

--- a/tests/test_Q_parameters.py
+++ b/tests/test_Q_parameters.py
@@ -33,3 +33,14 @@ def test_parameters_reuse():
 		sql="select 1 where abc = ( :1,:2,:3 ) or def in ( :1,:2,:3 )",
 		parameters=[1, 2, 3]
 	)
+
+def test_parameters_getattr():
+	p = Parameters(
+		abc='abc'
+	)
+	q = Q(lambda: f"select 1 where abc = {p.abc}", p)
+
+	assert q.build() == RenderedQuery(
+		sql="select 1 where abc = :1",
+		parameters=['abc']
+	)


### PR DESCRIPTION
Added `__getattr__` to Parameters class that replicates the `__getitem__` logic.

Based on the following hackernews comment from oefrha

> Advice on the Parameters class: implement attribute access (__getattr__) in addition to __getitem__. Compare
> 
>   f"""... WHERE created_on > {p['created_on']}} ..."""
> 
> to
> 
>   f"""... WHERE created_on > {p.created_on} ..."""
> 
> The latter is a lot more readable and typeable, especially when it's meant to be used in f-strings which place additional restrictions on the usage of quotes.